### PR TITLE
add a vignette title for vignette index

### DIFF
--- a/vignettes/sass.Rmd
+++ b/vignettes/sass.Rmd
@@ -4,7 +4,7 @@ author: "Timothy Mastny"
 date: "2018-08-14"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Vignette Title}
+  %\VignetteIndexEntry{Introduction to Sass}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
Currently, the vignette title does not appear in vignette index. 
See CRAN: https://cran.r-project.org/web//packages/sass/index.html
![image](https://user-images.githubusercontent.com/6791940/59566234-876df780-905d-11e9-852e-fba79db872d6.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rstudio/sass/21)
<!-- Reviewable:end -->
