### PR TITLE
Better naming of sass_layer() arguments

### DIFF
--- a/R/as_sass.R
+++ b/R/as_sass.R
@@ -106,7 +106,7 @@ as_sass_.list <- function(input) {
 }
 
 as_sass_.sass_layer <- function(input) {
-  as_sass_(list(input$pre, input$post))
+  as_sass_(list(input$before, input$after))
 }
 
 as_sass_.character <- function(input) {

--- a/R/layers.R
+++ b/R/layers.R
@@ -6,9 +6,9 @@
 #'
 #' @md
 #' @param ... A collection of [sass_layer()]s and/or objects that [as_sass()] understands.
-#' @param pre A suitable [sass::as_sass()] `input`.
-#' @param post A suitable [sass::as_sass()] `input`.
-#' @param deps An HTML dependency (or a list of them).
+#' @param before A suitable [sass::as_sass()] `input`.
+#' @param after A suitable [sass::as_sass()] `input`.
+#' @param html_deps An HTML dependency (or a list of them).
 #' @export
 #' @examples
 #' blue <- list(color = "blue !default")
@@ -16,16 +16,16 @@
 #' green <- list(color = "green !default")
 #'
 #' # a sass_layer() by itself is not very useful, it just defines some
-#' # SASS to place before (pre) and after (post)
-#' core <- sass_layer(pre = blue, post = "body { color: $color; }")
+#' # SASS to place before (before) and after (after)
+#' core <- sass_layer(before = blue, after = "body { color: $color; }")
 #' core
 #' sass(core)
 #'
 #' # However, by stacking sass_layer()s, we have ability to place
-#' # SASS both before (pre) and after (post) some other sass (e.g., core)
+#' # SASS both before and after some other sass (e.g., core)
 #' # Here we place a red default _before_ the blue default and export the
 #' # color SASS variable as a CSS variable _after_ the core
-#' red_layer <- sass_layer(red, post = ":root{ --color: #{$color}; }")
+#' red_layer <- sass_layer(red, after = ":root{ --color: #{$color}; }")
 #' sass(sass_layer_merge(core, red_layer))
 #' sass(sass_layer_merge(core, red_layer, sass_layer(green)))
 #'
@@ -33,35 +33,35 @@ sass_layer_merge <- function(...) {
   layers <- dropNulls(rlang::list2(...))
   is_layer <- vapply(layers, is_sass_layer, logical(1))
   layers[!is_layer] <- lapply(layers[!is_layer], function(x) {
-    sass_layer(post = x)
+    sass_layer(after = x)
   })
   Reduce(sass_layers_join, layers)
 }
 
 #' @rdname sass_layer_merge
 #' @export
-sass_layer <- function(pre = "", post = "", deps = NULL) {
-  if (inherits(deps, "html_dependency")) {
-    deps <- list(deps)
+sass_layer <- function(before = "", after = "", html_deps = NULL) {
+  if (inherits(html_deps, "html_dependency")) {
+    html_deps <- list(html_deps)
   }
-  if (!is.null(deps)) {
-    is_dependency <- vapply(deps, inherits, logical(1), "html_dependency")
-    if (any(!is_dependency)) stop("deps must be a collection of htmltools::htmlDependency() objects", call. = FALSE)
+  if (!is.null(html_deps)) {
+    is_dependency <- vapply(html_deps, inherits, logical(1), "html_dependency")
+    if (any(!is_dependency)) stop("html_deps must be a collection of htmltools::htmlDependency() objects", call. = FALSE)
   }
 
   layer <- list(
-    pre = as_sass(pre),
-    post = as_sass(post),
-    deps = deps
+    before = as_sass(before),
+    after = as_sass(after),
+    html_deps = html_deps
   )
   structure(layer, class = "sass_layer")
 }
 
 sass_layers_join <- function(layer1, layer2) {
   sass_layer(
-    pre = as_sass(list(layer2$pre, layer1$pre)),
-    post = as_sass(list(layer1$post, layer2$post)),
-    deps = c(layer1$deps, layer2$deps)
+    before = as_sass(list(layer2$before, layer1$before)),
+    after = as_sass(list(layer1$after, layer2$after)),
+    html_deps = c(layer1$html_deps, layer2$html_deps)
   )
 }
 
@@ -86,7 +86,7 @@ html_dependencies <- function(x) {
   deps <- c(deps, html_deps)
 
   if (is_sass_layer(x)) {
-    deps <- c(deps, x$deps)
+    deps <- c(deps, x$html_deps)
   }
 
   # recursive case

--- a/man/sass_layer_merge.Rd
+++ b/man/sass_layer_merge.Rd
@@ -7,16 +7,16 @@
 \usage{
 sass_layer_merge(...)
 
-sass_layer(pre = "", post = "", deps = NULL)
+sass_layer(before = "", after = "", html_deps = NULL)
 }
 \arguments{
 \item{...}{A collection of \code{\link[=sass_layer]{sass_layer()}}s and/or objects that \code{\link[=as_sass]{as_sass()}} understands.}
 
-\item{pre}{A suitable \code{\link[sass:as_sass]{sass::as_sass()}} \code{input}.}
+\item{before}{A suitable \code{\link[sass:as_sass]{sass::as_sass()}} \code{input}.}
 
-\item{post}{A suitable \code{\link[sass:as_sass]{sass::as_sass()}} \code{input}.}
+\item{after}{A suitable \code{\link[sass:as_sass]{sass::as_sass()}} \code{input}.}
 
-\item{deps}{An HTML dependency (or a list of them).}
+\item{html_deps}{An HTML dependency (or a list of them).}
 }
 \description{
 \code{\link[=sass_layer]{sass_layer()}} defines \code{\link[sass:sass]{sass::sass()}} input(s) to place before and after
@@ -29,16 +29,16 @@ red <- list(color = "red !default")
 green <- list(color = "green !default")
 
 # a sass_layer() by itself is not very useful, it just defines some
-# SASS to place before (pre) and after (post)
-core <- sass_layer(pre = blue, post = "body { color: $color; }")
+# SASS to place before (before) and after (after)
+core <- sass_layer(before = blue, after = "body { color: $color; }")
 core
 sass(core)
 
 # However, by stacking sass_layer()s, we have ability to place
-# SASS both before (pre) and after (post) some other sass (e.g., core)
+# SASS both before and after some other sass (e.g., core)
 # Here we place a red default _before_ the blue default and export the
 # color SASS variable as a CSS variable _after_ the core
-red_layer <- sass_layer(red, post = ":root{ --color: #{$color}; }")
+red_layer <- sass_layer(red, after = ":root{ --color: #{$color}; }")
 sass(sass_layer_merge(core, red_layer))
 sass(sass_layer_merge(core, red_layer, sass_layer(green)))
 

--- a/tests/testthat/test-html-dependencies.R
+++ b/tests/testthat/test-html-dependencies.R
@@ -17,10 +17,10 @@ dep2 <- htmlDependency(
 )
 
 test_that("sass() relays sass_layer()'s html dependencies", {
-  layer1 <- sass_layer(pre = "body{color: green}", deps = dep1)
+  layer1 <- sass_layer(before = "body{color: green}", html_deps = dep1)
   input1 <- list(layer1, "body{color: red}")
   expect_equal(htmlDependencies(sass(input1)), list(dep1))
-  layer2 <- sass_layer(pre = "body{color: blue}", deps = dep2)
+  layer2 <- sass_layer(before = "body{color: blue}", html_deps = dep2)
   input2 <- sass_layer_merge(layer1, layer2)
   expect_equal(htmlDependencies(sass(input2)), list(dep1, dep2))
 })

--- a/tests/testthat/test-layers.R
+++ b/tests/testthat/test-layers.R
@@ -3,7 +3,7 @@ context("layers")
 blue <- list(color = "blue !default")
 red <- list(color = "red !default")
 green <- list(color = "green !default")
-core <- sass_layer(pre = blue, post = "body { color: $color; }")
+core <- sass_layer(before = blue, after = "body { color: $color; }")
 
 test_that("sass_layer is equivalent to sass", {
   expect_equivalent(


### PR DESCRIPTION
After some reflection, `before`/`after`/`html_deps` seem to be more clearly self-descriptive names `pre`/`post`/`deps`