### PR TITLE
Add knit_print methods for better printing defaults in knitr/rmarkdown

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,11 @@
 # sass 0.1.2.9000
 
-* Added the `sass_layer()` and `sass_layer_merge()` functions.
-* Added the ability for `sass()` to retain `htmltools::htmlDependency()`s attached to it's `input`. 
+* Added new `sass_layer()` and `sass_layer_merge()` functions. See [here](https://rstudio.github.io/sass/articles/sass.html#layers) for more details.
+
+* The objects that `sass()` and `as_sass()`) return now have better print methods in **rmarkdown**. See [here](https://rstudio.github.io/sass/articles/sass.html#rmarkdown) for more details.
+
+* Added the ability for `sass()` to retain `htmltools::htmlDependency()`s attached to it's `input`.  
+
 
 # sass 0.1.2
 

--- a/R/format.R
+++ b/R/format.R
@@ -24,3 +24,53 @@ print.css <- function(x, ...) {
 print.sass <- function(x, ...) {
   cat0("/* Sass */\n", format(x), "\n") # nolint
 }
+
+
+knit_print.css <- function(x, options, ...) {
+  # Display the CSS as a string
+  if (identical(options$class.output, 'css')) {
+    return(as.character(x))
+  }
+  # Embed the CSS as HTML
+  knitr::knit_print(htmltools::tags$style(x))
+}
+
+knit_print.sass <- function(x, options, ...) {
+  knit_print.css(sass(x), options, ...)
+}
+
+# Reusable function for registering a set of methods with S3 manually. The
+# methods argument is a list of character vectors, each of which has the form
+# c(package, genname, class).
+registerMethods <- function(methods) {
+  lapply(methods, function(method) {
+    pkg <- method[[1]]
+    generic <- method[[2]]
+    class <- method[[3]]
+    func <- get(paste(generic, class, sep="."))
+    if (pkg %in% loadedNamespaces()) {
+      registerS3method(generic, class, func, envir = asNamespace(pkg))
+    }
+    setHook(
+      packageEvent(pkg, "onLoad"),
+      function(...) {
+        registerS3method(generic, class, func, envir = asNamespace(pkg))
+      }
+    )
+  })
+}
+
+.onLoad <- function(...) {
+  # htmltools provides methods for knitr::knit_print, but knitr isn't a Depends or
+  # Imports of htmltools, only an Enhances. Therefore, the NAMESPACE file has to
+  # declare it as an export, not an S3method. That means that R will only know to
+  # use our methods if htmltools is actually attached, i.e., you have to use
+  # library(htmltools) in a knitr document or else you'll get escaped HTML in your
+  # document. This code snippet manually registers our methods with S3 once both
+  # htmltools and knitr are loaded.
+  registerMethods(list(
+    # c(package, genname, class)
+    c("knitr", "knit_print", "css"),
+    c("knitr", "knit_print", "sass")
+  ))
+}


### PR DESCRIPTION
When `sass()` and `as_sass()` objects are printed in knitr/rmarkdown, it seems sensible to embed the CSS as HTML. If one wishes to display CSS source code instead of embedding, I'm thinking they can do that by setting `class.output='css'` and `comment=''`.

## Testing notes

Install `remotes::install_github('rstudio/sass#30')`, then `rmarkdown::render()` the following document: https://gist.githubusercontent.com/cpsievert/e7086e9b57d7e03b4ecc5213d70d3b26/raw/3616966edd702f328bc0ae50acd07f2eb4fe5ecf/sass-printing.Rmd

The background color should be black, the text color should be white, and the CSS code chunks should have syntax highlighting

