### PR TITLE
Recursively find mtimes for attachments

### DIFF
--- a/R/sass.R
+++ b/R/sass.R
@@ -64,7 +64,7 @@ sass <- function(input = NULL, options = sass_options(), output = NULL,
       # Detect if any attachments have changed - note that if the attachment is
       # a directory, it will detect if files are added or removed, but it will
       # not detect if a file in the directory is modified.
-      if (is.list(layer) && !is.null(layer$file_attachments)) file.mtime(layer$file_attachments),
+      if (is.list(layer) && !is.null(layer$file_attachments)) get_file_mtimes(layer$file_attachments),
       options
     ))
     cache_hit <- FALSE

--- a/R/sass.R
+++ b/R/sass.R
@@ -2,6 +2,30 @@
 #'
 #' Compile Sass to CSS using LibSass.
 #'
+#' @details
+#'
+#' @section Caching:
+#'
+#'   If caching is used (as is the default), then this function checks for
+#'   changes in `input` and `options`, as well as any .sass/.scss files
+#'   specified in `input`, and file attachments (such as fonts) specified in
+#'   `input`. All of that information is hashed to create a key which is used
+#'   for caching.
+#'
+#'   For .sass/.scss files, the mtime of the specified file(s) will be checked
+#'   each time `sass()` is called and those times will be included in a hash; if
+#'   the mtime changes, it will result in a new hash key and the .css will be
+#'   recompiled. However, if the file imports other files (via an `@import`
+#'   directive), those mtimes of those imported files will not be checked.
+#'   Changes to those files will not be detected, and the .css file will not be
+#'   recompiled. For this reason, if you are actively developing a sass theme,
+#'   then it is best to turn off caching.
+#'
+#'   For file attachments, like font files, the mtime of specified files will be
+#'   checked for changes each time `sass()` is called. If a directory is
+#'   specified, then all the files within the directory will have their mtime
+#'   computed and used as part of the hash. Any changes to those files will
+#'   result in a new hash key, and output directory.
 #'
 #' @param input Accepts raw Sass, a named list of variables, or a list of raw
 #'   Sass and/or named variables. See \code{\link{as_sass}} and
@@ -61,9 +85,7 @@ sass <- function(input = NULL, options = sass_options(), output = NULL,
   if (!is.null(cache)) {
     cache_key <- sass_hash(list(
       input,
-      # Detect if any attachments have changed - note that if the attachment is
-      # a directory, it will detect if files are added or removed, but it will
-      # not detect if a file in the directory is modified.
+      # Detect if any attachments have changed
       if (is.list(layer) && !is.null(layer$file_attachments)) get_file_mtimes(layer$file_attachments),
       options
     ))

--- a/R/utils.R
+++ b/R/utils.R
@@ -49,6 +49,7 @@ get_file_mtimes <- function(files) {
 
   data.frame(
     file = rownames(all_info),
-    mtime = all_info$mtime
+    mtime = all_info$mtime,
+    stringsAsFactors = FALSE
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -27,3 +27,28 @@ read_utf8 <- function(file) {
   res <- read_raw(file)
   raw_to_utf8(res)
 }
+
+
+# `file` must be a character vector with files and directories. This will return
+# a data frame with the mtimes of all files that are passed in, as well as the
+# mtimes of files in the directories that are passed in. The data frame will not
+# contain the mtimes of the directories themselves. Also, any files that were
+# passed in but don't exist will not be present in the returned data frame.
+get_file_mtimes <- function(files) {
+  info <- file.info(files, extra_cols = FALSE)
+
+  dirs <- files[info$isdir & !is.na(info$isdir)]
+  files_in_dirs <- dir(dirs, full.names = TRUE, all.files = TRUE, recursive = TRUE, no.. = TRUE)
+  files_in_dirs_info <- file.info(files_in_dirs, extra_cols = FALSE)
+
+  all_info <- rbind(
+    # The (non-dir) files that were passed in directly
+    info[!info$isdir & !is.na(info$isdir), , drop = FALSE],
+    files_in_dirs_info
+  )
+
+  data.frame(
+    file = rownames(all_info),
+    mtime = all_info$mtime
+  )
+}

--- a/man/sass.Rd
+++ b/man/sass.Rd
@@ -40,6 +40,34 @@ to that file and \code{invisible()} is returned.
 \description{
 Compile Sass to CSS using LibSass.
 }
+\details{
+
+}
+\section{Caching}{
+
+
+If caching is used (as is the default), then this function checks for
+changes in \code{input} and \code{options}, as well as any .sass/.scss files
+specified in \code{input}, and file attachments (such as fonts) specified in
+\code{input}. All of that information is hashed to create a key which is used
+for caching.
+
+For .sass/.scss files, the mtime of the specified file(s) will be checked
+each time \code{sass()} is called and those times will be included in a hash; if
+the mtime changes, it will result in a new hash key and the .css will be
+recompiled. However, if the file imports other files (via an \verb{@import}
+directive), those mtimes of those imported files will not be checked.
+Changes to those files will not be detected, and the .css file will not be
+recompiled. For this reason, if you are actively developing a sass theme,
+then it is best to turn off caching.
+
+For file attachments, like font files, the mtime of specified files will be
+checked for changes each time \code{sass()} is called. If a directory is
+specified, then all the files within the directory will have their mtime
+computed and used as part of the hash. Any changes to those files will
+result in a new hash key, and output directory.
+}
+
 \examples{
 # raw Sass input
 sass("foo { margin: 122px * .3; }")


### PR DESCRIPTION
Here's an example of the output of `get_file_mtimes()`. Note that you can pass it files or directories. It will find all the files in the directories and give the mtimes of the files (but not mtimes of the directories themselves). If any filenames are passed in and the file doesn't exist (like `"foo"` below), it won't return any information for that filename.


```R
get_file_mtimes(c("inst", "foo", "R", "DESCRIPTION"))
#>                                                             file               mtime
#> 1                                                    DESCRIPTION 2020-09-02 13:11:55
#> 2                                          inst/sass-color/app.R 2018-10-19 15:33:58
#> 3                                    inst/sass-color/DESCRIPTION 2018-10-19 15:33:58
#> 4                                      inst/sass-color/README.md 2018-10-19 15:33:58
#> 5  inst/sass-color/rsconnect/shinyapps.io/gallery/sass-color.dcf 2018-10-19 15:33:58
#> 6                                           inst/sass-font/app.R 2018-10-19 15:33:58
#> 7                                     inst/sass-font/DESCRIPTION 2018-10-19 15:33:58
#> 8                                       inst/sass-font/README.md 2018-10-19 15:33:58
#> 9    inst/sass-font/rsconnect/shinyapps.io/gallery/sass-font.dcf 2018-10-19 15:33:58
#> 10                                 inst/sass-font/sass-font.scss 2018-10-19 15:33:58
#> 11                                          inst/sass-size/app.R 2018-10-19 15:33:58
#> 12                                    inst/sass-size/DESCRIPTION 2018-10-19 15:33:58
#> 13                                      inst/sass-size/README.md 2018-10-19 15:33:58
#> 14   inst/sass-size/rsconnect/shinyapps.io/gallery/sass-size.dcf 2018-10-19 15:33:58
#> 15                                 inst/sass-size/sass-size.scss 2018-10-19 15:33:58
#> 16                                         inst/sass-theme/app.R 2018-10-19 15:33:58
#> 17                                   inst/sass-theme/DESCRIPTION 2018-10-19 15:33:58
#> 18                                     inst/sass-theme/README.md 2018-10-19 15:33:58
#> 19 inst/sass-theme/rsconnect/shinyapps.io/gallery/sass-theme.dcf 2018-10-19 15:33:58
#> 20                                                   R/as_html.R 2018-10-19 15:33:58
#> 21                                                   R/as_sass.R 2020-09-02 13:11:55
#> 22                                                   R/compile.R 2018-10-19 15:33:58
#> 23                                                R/file_cache.R 2020-09-02 13:11:55
#> 24                                                    R/format.R 2020-08-28 20:37:20
#> 25                                                    R/layers.R 2020-08-26 13:12:02
#> 26                                                   R/options.R 2020-09-02 13:11:55
#> 27                                                R/sass_cache.R 2020-09-02 13:11:55
#> 28                                                      R/sass.R 2020-09-02 15:32:35
#> 29                                                     R/utils.R 2020-09-02 15:32:26
```

Performance is fast enough, IMO:

```R
system.time(get_file_mtimes(c("inst", "foo","R", "DESCRIPTION")))
#>    user  system elapsed 
#>   0.001   0.001   0.002 
```
