### PR TITLE
Replace fs functions with faster base functions

### DIFF
--- a/R/layers.R
+++ b/R/layers.R
@@ -206,8 +206,17 @@ write_file_attachments <- function(file_attachments, output_path) {
   output_path <- normalizePath(output_path, mustWork = TRUE)
 
   mapply(function(dest, src) {
-    if (fs::is_dir(src)) {
-      fs::dir_copy(src, file.path(output_path, dest), overwrite = TRUE)
+    if (dir.exists(src)) {
+      dest <- file.path(output_path, dest)
+      if (!dir.exists(dest)) {
+        dir.create(dest)
+      }
+      file.copy(
+        dir(src, all.files = TRUE, full.names = TRUE, no.. = TRUE),
+        dest,
+        overwrite = TRUE,
+        recursive = TRUE
+      )
       return(NULL)
     }
 

--- a/R/layers.R
+++ b/R/layers.R
@@ -211,6 +211,8 @@ write_file_attachments <- function(file_attachments, output_path) {
       if (!dir.exists(dest)) {
         dir.create(dest)
       }
+      # We previously used fs::dir_copy(), but changed to file.copy2 for
+      # performance reasons. https://github.com/rstudio/sass/pull/53
       file.copy2(
         dir(src, all.files = TRUE, full.names = TRUE, no.. = TRUE),
         dest,

--- a/R/layers.R
+++ b/R/layers.R
@@ -211,7 +211,7 @@ write_file_attachments <- function(file_attachments, output_path) {
       if (!dir.exists(dest)) {
         dir.create(dest)
       }
-      file.copy(
+      file.copy2(
         dir(src, all.files = TRUE, full.names = TRUE, no.. = TRUE),
         dest,
         overwrite = TRUE,

--- a/R/layers.R
+++ b/R/layers.R
@@ -209,7 +209,7 @@ write_file_attachments <- function(file_attachments, output_path) {
     if (dir.exists(src)) {
       dest <- file.path(output_path, dest)
       if (!dir.exists(dest)) {
-        dir.create(dest)
+        dir.create2(dest)
       }
       # We previously used fs::dir_copy(), but changed to file.copy2 for
       # performance reasons. https://github.com/rstudio/sass/pull/53

--- a/R/utils.R
+++ b/R/utils.R
@@ -57,3 +57,13 @@ get_file_mtimes <- function(files) {
 "%||%" <- function(x, y) {
   if (is.null(x)) y else x
 }
+
+# Wrapper for file.copy that throws if any files fail to copy. Use name
+# file.copy2 to make clear that it's a wrapper for a base function, and not for
+# fs::file_copy.
+file.copy2 <- function(from, to, ...) {
+  res <- file.copy(from, to, ...)
+  if (!all(res)) {
+    stop("Error copying files: ", paste0(from[!res], collapse = ", "))
+  }
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -67,3 +67,10 @@ file.copy2 <- function(from, to, ...) {
     stop("Error copying files: ", paste0(from[!res], collapse = ", "))
   }
 }
+
+dir.create2 <- function(path, ...) {
+  res <- dir.create(path, ...)
+  if (!res) {
+    stop("Error creating directory: ", path)
+  }
+}


### PR DESCRIPTION
This replaces `fs::is_dir` and `fs::dir_copy` with functions from base.

Here is a test that I profiled on R 3.6.3 on rstudio.cloud (note that the profiler in R 4.0 has a bug that prevents it from generating useful data):

```R
library(bootstraplib)
library(sass)
library(profvis)
profvis({
  for (i in 1:30)
    bootstrap(bs_theme_create(), use_precompiled_css = TRUE)
})
```


Here's what it looked like before the change. Total time was 800ms, and 370 of that was in `fs::dir_copy`.

<img width="1540" alt="Screen Shot 2020-09-17 at 8 54 40 PM" src="https://user-images.githubusercontent.com/86978/93546761-22244880-f929-11ea-997e-e3d4d8ab13bc.png">


After the change, total time is 400ms, and 10 of that is spent copying files.

<img width="1533" alt="Screen Shot 2020-09-17 at 9 04 54 PM" src="https://user-images.githubusercontent.com/86978/93546909-834c1c00-f929-11ea-9e0a-cea1a282118c.png">
