### PR TITLE
make sass_layer()'s html_deps also allow tagFunction()s

### DIFF
--- a/R/layers.R
+++ b/R/layers.R
@@ -131,13 +131,16 @@ sass_layer_struct <- function(
 
   validate_attachments(file_attachments)
 
-  if (is_dependency_maybe(html_deps)) {
-    html_deps <- list(html_deps)
-  }
   if (!is.null(html_deps)) {
+    if (is_dependency_maybe(html_deps)) {
+      html_deps <- list(html_deps)
+    }
+    if (!is.list(html_deps)) {
+      stop("`html_deps` must be a collection of htmlDependency() and/or tagFunction() objects")
+    }
     is_dependency <- vapply(html_deps, is_dependency_maybe, logical(1))
     if (any(!is_dependency)) {
-      warning("Expected html_deps to be a collection of htmlDependency() or tagFunction() objects", call. = FALSE)
+      stop("`html_deps` must be a collection of htmlDependency() and/or tagFunction() objects")
     }
   }
 

--- a/R/layers.R
+++ b/R/layers.R
@@ -131,12 +131,14 @@ sass_layer_struct <- function(
 
   validate_attachments(file_attachments)
 
-  if (inherits(html_deps, "html_dependency")) {
+  if (is_dependency_maybe(html_deps)) {
     html_deps <- list(html_deps)
   }
   if (!is.null(html_deps)) {
-    is_dependency <- vapply(html_deps, inherits, logical(1), "html_dependency")
-    if (any(!is_dependency)) stop("html_deps must be a collection of htmltools::htmlDependency() objects", call. = FALSE)
+    is_dependency <- vapply(html_deps, is_dependency_maybe, logical(1))
+    if (any(!is_dependency)) {
+      warning("Expected html_deps to be a collection of htmlDependency() or tagFunction() objects", call. = FALSE)
+    }
   }
 
   layer <- list(
@@ -147,6 +149,10 @@ sass_layer_struct <- function(
     file_attachments = file_attachments
   )
   add_class(layer, "sass_layer")
+}
+
+is_dependency_maybe <- function(x) {
+  inherits(x, "html_dependency") || inherits(x, "shiny.tag.function")
 }
 
 validate_layer_param <- function(x, name) {


### PR DESCRIPTION
Needed for https://github.com/rstudio/bootstraplib/pull/139 and need more generally when you want to generate HTML dependencies at run-time via a `sass_layer()`