### PR TITLE
Use `tools::R_user_dir()` when available

### DIFF
--- a/R/sass_cache.R
+++ b/R/sass_cache.R
@@ -93,7 +93,8 @@ sass_cache_set_dir <- function(dir, cache) {
 #' to a `sass_file_cache()` object, then it will return that object.
 #'
 #' In most cases, this function uses the user's cache directory, by calling
-#' `rappdirs::user_cache_dir("R-sass")`.
+#' `tools::R_user_dir("sass", which = "cache")` (for R 4.0 and above) or
+#' `rappdirs::user_cache_dir("R-sass")` (for older versions of R).
 #'
 #' If this function is called from a Shiny application, it will also look for a
 #' subdirectory named `app_cache/`. If it exists, it will use a directory named
@@ -157,7 +158,7 @@ sass_cache_context_dir <- function() {
   tryCatch(
     {
       # The usual place we'll look. This may be superseded below.
-      cache_dir <- rappdirs::user_cache_dir("R-sass")
+      cache_dir <- find_cache_dir("sass")
 
       if (is_shiny_app()) {
         # We might use ./cache/sass, if it's a hosted app, or if the directory
@@ -231,6 +232,19 @@ add_sass_file_mtime <- function(x) {
     x
   }
 }
+
+
+find_cache_dir <- function(pkg) {
+  # In R 4.0 and above, CRAN wants us to use the new tools::R_user_dir().
+  # If not present, fall back to rappdirs::user_cache_dir().
+  R_user_dir <- getNamespace('tools')$R_user_dir
+  if (!is.null(R_user_dir)) {
+    R_user_dir(pkg, which = "cache")
+  } else {
+    rappdirs::user_cache_dir(paste0("R-", pkg))
+  }
+}
+
 
 #' Caching Options for Sass (defunct)
 #'

--- a/man/sass_cache_get.Rd
+++ b/man/sass_cache_get.Rd
@@ -17,7 +17,8 @@ it is treated as a directory name, and this function returns a
 to a \code{sass_file_cache()} object, then it will return that object.
 
 In most cases, this function uses the user's cache directory, by calling
-\code{rappdirs::user_cache_dir("R-sass")}.
+\code{tools::R_user_dir("sass", which = "cache")} (for R 4.0 and above) or
+\code{rappdirs::user_cache_dir("R-sass")} (for older versions of R).
 
 If this function is called from a Shiny application, it will also look for a
 subdirectory named \verb{app_cache/}. If it exists, it will use a directory named


### PR DESCRIPTION
This is to address the following message from CRAN:

```
Checking this on Linux creates and leaves behind

  ~/.cache/R-sass

in violation of the CRAN Policy's

  Packages should not write in the user's home filespace (including
  clipboards), nor anywhere else on the file system apart from the R
  session's temporary directory (or during installation in the location
  pointed to by TMPDIR: and such usage should be cleaned up). Installing
  into the system's R installation (e.g., scripts to its bin directory)
  is not allowed.

  Limited exceptions may be allowed in interactive sessions if the
  package obtains confirmation from the user.

  For R version 4.0 or later (hence a version dependency is required or
  only conditional use is possible), packages may store user-specific
  data, configuration and cache files in their respective user
  directories obtained from tools::R_user_dir(), provided that by
  default sizes are kept as small as possible and the contents are
  actively managed (including removing outdated material).

Can you please change as necessary, ideally using the
tools::R_user_dir() mechanism where available?

Please fix before 2021-01-27 to safely retain your package on CRAN.
```

This is essentially the same fix as https://github.com/rstudio/bslib/pull/226.