### PR TITLE
Add a temp_dir argument to `output_template`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,8 @@ Authors@R: c(
            comment = c(ORCID = "0000-0001-9986-114X")),
     person("Carson", "Sievert", , "carson@rstudio.com", c("aut", "cre"),
            comment = c(ORCID = "0000-0002-4958-2844")),
+    person("Christophe", "Dervieux", , "cderv@rstudio.com", c("ctb"),
+           comment = c(ORCID = "0000-0003-4474-2498")),
     person(family = "RStudio", role = c("cph", "fnd")),
     person(family = "Sass Open Source Foundation", role = c("ctb", "cph"),
            comment = "LibSass library"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * Added new font importing helpers, namely `font_google()`, `font_link()`, `font_face()`, and `font_collection()` for intelligently importing web fonts files. They must be used inside a named list, for example: `list("font-variable" = font_google("Pacifico"))`. See `help(font_face, package = "sass")` for more details and examples.
 
+* `output_template()` gains a `temp_dir` argument to change the directory where output file will be written.
+
 # sass 0.3.1
 
 This small patch release changes `sass::sass_cache_context_dir()` to use `tools::R_user_dir()` over `rappdirs::user_cache_dir()` (when relevant, as requested by CRAN). (#70)

--- a/R/sass.R
+++ b/R/sass.R
@@ -301,7 +301,7 @@ sass_partial <- function(
 #'   directory name.
 #' @param fileext the output file extension. The default is `".min.css"` for
 #'   compressed and compact output styles; otherwise, its `".css"`.
-#' @param temp_dir the output directory to write the temporary file to. The
+#' @param tmpdir the output directory to write the temporary file to. The
 #'   default is `tempdir()` to write in the R session temp directory.
 #'
 #' @return A function with two arguments: `options` and `suffix`. When called inside
@@ -314,15 +314,15 @@ sass_partial <- function(
 #' func <- output_template(basename = "foo", dirname = "bar-")
 #' func(suffix = "baz")
 #'
-output_template <- function(basename = "sass", dirname = basename, fileext = NULL, temp_dir = tempdir()) {
+output_template <- function(basename = "sass", dirname = basename, fileext = NULL, tmpdir = tempdir()) {
   function(options = list(), suffix = NULL) {
     fileext <- fileext %||% if (isTRUE(options$output_style %in% c(2, 3))) ".min.css" else ".css"
     # If caching is enabled, then make sure the out dir is unique to the cache key;
     # otherwise, do the more conservative thing of making sure there is a fresh start everytime
     out_dir <- if (is.null(suffix)) {
-      tempfile(tmpdir = temp_dir, pattern = dirname)
+      tempfile(tmpdir, pattern = dirname)
     } else {
-      file.path(temp_dir, paste0(dirname, suffix))
+      file.path(tmpdir, paste0(dirname, suffix))
     }
     if (!dir.exists(out_dir)) {
       dir.create(out_dir, recursive = TRUE)

--- a/R/sass.R
+++ b/R/sass.R
@@ -301,6 +301,8 @@ sass_partial <- function(
 #'   directory name.
 #' @param fileext the output file extension. The default is `".min.css"` for
 #'   compressed and compact output styles; otherwise, its `".css"`.
+#' @param temp_dir the output directory to write the temporary file to. The
+#'   default is `tempdir()` to write in the R session temp directory.
 #'
 #' @return A function with two arguments: `options` and `suffix`. When called inside
 #' [sass()] with caching enabled, the caching key is supplied to `suffix`.
@@ -312,15 +314,15 @@ sass_partial <- function(
 #' func <- output_template(basename = "foo", dirname = "bar-")
 #' func(suffix = "baz")
 #'
-output_template <- function(basename = "sass", dirname = basename, fileext = NULL) {
+output_template <- function(basename = "sass", dirname = basename, fileext = NULL, temp_dir = tempdir()) {
   function(options = list(), suffix = NULL) {
     fileext <- fileext %||% if (isTRUE(options$output_style %in% c(2, 3))) ".min.css" else ".css"
     # If caching is enabled, then make sure the out dir is unique to the cache key;
     # otherwise, do the more conservative thing of making sure there is a fresh start everytime
     out_dir <- if (is.null(suffix)) {
-      tempfile(pattern = dirname)
+      tempfile(tmpdir = temp_dir, pattern = dirname)
     } else {
-      file.path(tempdir(), paste0(dirname, suffix))
+      file.path(temp_dir, paste0(dirname, suffix))
     }
     if (!dir.exists(out_dir)) {
       dir.create(out_dir, recursive = TRUE)

--- a/R/sass.R
+++ b/R/sass.R
@@ -320,7 +320,7 @@ output_template <- function(basename = "sass", dirname = basename, fileext = NUL
     # If caching is enabled, then make sure the out dir is unique to the cache key;
     # otherwise, do the more conservative thing of making sure there is a fresh start everytime
     out_dir <- if (is.null(suffix)) {
-      tempfile(tmpdir, pattern = dirname)
+      tempfile(tmpdir = tmpdir, pattern = dirname)
     } else {
       file.path(tmpdir, paste0(dirname, suffix))
     }

--- a/man/output_template.Rd
+++ b/man/output_template.Rd
@@ -8,7 +8,7 @@ output_template(
   basename = "sass",
   dirname = basename,
   fileext = NULL,
-  temp_dir = tempdir()
+  tmpdir = tempdir()
 )
 }
 \arguments{
@@ -21,7 +21,7 @@ directory name.}
 \item{fileext}{the output file extension. The default is \code{".min.css"} for
 compressed and compact output styles; otherwise, its \code{".css"}.}
 
-\item{temp_dir}{the output directory to write the temporary file to. The
+\item{tmpdir}{the output directory to write the temporary file to. The
 default is \code{tempdir()} to write in the R session temp directory.}
 }
 \value{

--- a/man/output_template.Rd
+++ b/man/output_template.Rd
@@ -4,7 +4,12 @@
 \alias{output_template}
 \title{An intelligent (temporary) output file}
 \usage{
-output_template(basename = "sass", dirname = basename, fileext = NULL)
+output_template(
+  basename = "sass",
+  dirname = basename,
+  fileext = NULL,
+  temp_dir = tempdir()
+)
 }
 \arguments{
 \item{basename}{a non-empty character vector giving the outfile name (without
@@ -15,6 +20,9 @@ directory name.}
 
 \item{fileext}{the output file extension. The default is \code{".min.css"} for
 compressed and compact output styles; otherwise, its \code{".css"}.}
+
+\item{temp_dir}{the output directory to write the temporary file to. The
+default is \code{tempdir()} to write in the R session temp directory.}
 }
 \value{
 A function with two arguments: \code{options} and \code{suffix}. When called inside

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -176,8 +176,13 @@ test_that("output_template() is cache and options aware", {
   expect_true(dirname(output5) != dirname(output6))
   expect_red(output5)
   expect_red(output6)
-})
 
+  # File can be written in another dir and still be cache aware
+  tmp_dir <- withr::local_tempdir()
+  output7 <- sass(input, output = output_template(temp_dir = tmp_dir), options = opts)
+  expect_true(basename(dirname(dirname(output7))) == basename(tmp_dir))
+  expect_true(basename(dirname(output7)) == basename(dirname(output1)))
+})
 
 test_that("Cache directory getting/setting", {
   cache_dir <- tempfile("sass-cache-test-")

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -178,9 +178,9 @@ test_that("output_template() is cache and options aware", {
   expect_red(output6)
 
   # File can be written in another dir and still be cache aware
-  tmp_dir <- withr::local_tempdir()
-  output7 <- sass(input, output = output_template(temp_dir = tmp_dir), options = opts)
-  expect_true(basename(dirname(dirname(output7))) == basename(tmp_dir))
+  temp_dir <- withr::local_tempdir()
+  output7 <- sass(input, output = output_template(tmpdir = temp_dir), options = opts)
+  expect_true(basename(dirname(dirname(output7))) == basename(temp_dir))
   expect_true(basename(dirname(output7)) == basename(dirname(output1)))
 })
 


### PR DESCRIPTION
This closes #75 by adding the function needed for https://github.com/rstudio/rmarkdown/pull/2095 in **sass** directly. 

This allows to change the directory used to write the output file of `sass()` when `output_template()` is used.