### PR TITLE
Start v0.4.1 release candidate

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -19,3 +19,7 @@ jobs:
     uses: rstudio/shiny-workflows/.github/workflows/routine.yaml@v1
   R-CMD-check:
     uses: rstudio/shiny-workflows/.github/workflows/R-CMD-check.yaml@v1
+    with:
+      # `{sass}` is not able to check on Windows R3.6 due to missing `SystemRequirements`
+      # If `false`, packages with a `src` folder will not test on Windows R3.6 using `rtools35`.
+      rtools-35: false

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Type: Package
 Package: sass
-Version: 0.4.0.9000
+Version: 0.4.1
 Title: Syntactically Awesome Style Sheets ('Sass')
 Description: An 'SCSS' compiler, powered by the 'LibSass' library. With this,
     R developers can use variables, inheritance, and functions to generate

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# sass 0.4.0.9000
+# sass 0.4.1
 
 ## Improvements
 


### PR DESCRIPTION
Closes #102 (see there for a full checklist)

TODO: 

- [x] Disable Win 3.6 check since that environment doesn't satisfy `SystemRequirements`