### PR TITLE
ensure CXX is used to link the final shared object

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Several speed improvements for `sass()` and `as_sass_layer()`, particularly when `sass(write_attachments = TRUE)` encounters a `cache` hit. (#98)
 * Removed compilation warnings with gcc-12. (#100)
+* Removed linking errors that occur when custom C++ flags are used to compile
+  (#94, #104).
 
 # sass 0.4.0
 

--- a/src/compile.h
+++ b/src/compile.h
@@ -3,7 +3,15 @@
 
 #include <Rinternals.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 SEXP compile_file(SEXP file, SEXP options);
 SEXP compile_data(SEXP data, SEXP options);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -7,7 +7,7 @@ static const R_CallMethodDef callMethods[]  = {
   {NULL, NULL, 0}
 };
 
-void R_init_sass(DllInfo* info) {
+extern "C" void R_init_sass(DllInfo* info) {
   R_registerRoutines(info, NULL, callMethods, NULL, NULL);
   R_useDynamicSymbols(info, FALSE);
   R_forceSymbols(info, TRUE);


### PR DESCRIPTION
This PR fixes #94, which is a similar problem to one we see in 'arrow' when compiling with slightly different C++ flags (in our case, `-stdlib=libc++` to replicate the custom clang build that exists on fedora-clang-devel; see https://github.com/apache/arrow/pull/12734). The final .so is getting linked with CC instead of CXX because there are no .cpp files (I think). This PR just renames init.c to init.cpp and includes the relevant changes to make sure that compile.c/compile.h work as they did before.

With reprex:

```bash
# docker pull rhub/fedora-clang-devel
/opt/R-devel/bin/R -e 'install.packages(c("withr", "remotes"), repos = "https://cloud.r-project.org/")'
/opt/R-devel/bin/R -e 'withr::with_makevars(list(CXX = "-stdlib=libc++"), remotes::install_github("rstudio/sass"), assignment = "+=")'
# ...
# ** testing if installed package can be loaded from temporary location
# Error: package or namespace load failed for ‘sass’ in dyn.load(file, DLLpath = DLLpath, ...):
#  unable to load shared object '/opt/R-devel/lib64/R/library/00LOCK-sass/00new/sass/libs/sass.so':
#   /opt/R-devel/lib64/R/library/00LOCK-sass/00new/sass/libs/sass.so: undefined symbol: _ZTINSt3__113basic_ostreamIcNS_11char_traitsIcEEEE
/opt/R-devel/bin/R -e 'withr::with_makevars(list(CXX = "-stdlib=libc++"), remotes::install_github("rstudio/sass#104"), assignment = "+=")'
# ...works!
```

