### PR TITLE
Properly replace whitespace in font family name with underscores

### DIFF
--- a/R/fonts.R
+++ b/R/fonts.R
@@ -355,7 +355,7 @@ quote_css_font_families <- function(x) {
 
 
 font_dep_name <- function(x) {
-  sub("\\s*", "_", trim_ws(x$family))
+  gsub("\\s+", "_", trim_ws(x$family))
 }
 
 #' @import htmltools

--- a/tests/testthat/test-font-objects.R
+++ b/tests/testthat/test-font-objects.R
@@ -66,6 +66,14 @@ test_that("font_google(local = TRUE) basically works", {
   )
   woff <- dir(src, pattern = "\\.woff$", full.names = TRUE)
   expect_true(length(woff) > 0)
+
+  # https://github.com/rstudio/bslib/issues/408
+  scss <- list(
+    list("my-font" = font_google("Crimson Pro")),
+    list("body {font-family: $my-font}")
+  )
+  tagz <- renderTags(tags$style(sass(scss)))
+  expect_equal(tagz$dependencies[[1]]$name, "Crimson_Pro")
 })
 
 expect_collection <- function(..., expected) {


### PR DESCRIPTION
Closes #105