### PR TITLE
Don't add -stdlib-libc++ to CFLAGS (it's a C++, not C, option)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # sass 0.4.6.9000
 
-
+* Closed #129: Fixed a compilation warning on latest Apple Clang (15). (#130)
 
 # sass 0.4.6
 

--- a/README.md
+++ b/README.md
@@ -5,22 +5,19 @@
 
 [![R build
 status](https://github.com/rstudio/sass/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/rstudio/sass/actions)
-[![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version/sass)](https://cran.r-project.org/package=sass)
+[![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/sass)](https://cran.r-project.org/package=sass)
 
 <style>
 pre {
   border: 1px solid #eee;
 }
-
-pre.r {
+&#10;pre.r {
   background-color: #ffffff;
 }
-
-pre.r code {
+&#10;pre.r code {
   background-color: #ffffff;
 }
-
-pre.css {
+&#10;pre.css {
   margin-top: -1.25rem;
   background-color: #f8f8f8;
   border-radius: 0;
@@ -57,13 +54,11 @@ remotes::install_github("rstudio/sass")
 To compile Sass into CSS, provide Sass to the `input` argument of the
 `sass()` function. `input` can be any of the following:
 
-  - An R string (as in the example below).
-  - A named `list()` defining [Sass
-    variables](https://rstudio.github.io/sass/articles/sass.html#variables).
-  - A `sass_file()`, `sass_import()`, or `sass_layer()`.
-  - A nested `list()` comprising of all the above.
-
-<!-- end list -->
+- An R string (as in the example below).
+- A named `list()` defining [Sass
+  variables](https://rstudio.github.io/sass/articles/sass.html#variables).
+- A `sass_file()`, `sass_import()`, or `sass_layer()`.
+- A nested `list()` comprising of all the above.
 
 ``` r
 library(sass)

--- a/scripts/patches/010-clang-15-address-warnings.patch
+++ b/scripts/patches/010-clang-15-address-warnings.patch
@@ -1,0 +1,12 @@
+diff --git a/src/libsass/Makefile b/src/libsass/Makefile
+index 6f81feb..41e3739 100644
+--- a/src/libsass/Makefile
++++ b/src/libsass/Makefile
+@@ -110,7 +110,6 @@ ifeq ($(STATIC_LIBSTDCPP),1)
+ endif
+ 
+ ifeq ($(UNAME),Darwin)
+-	CFLAGS += -stdlib=libc++
+ 	CXXFLAGS += -stdlib=libc++
+ 	LDFLAGS += -stdlib=libc++
+ endif

--- a/src/libsass/Makefile
+++ b/src/libsass/Makefile
@@ -110,7 +110,6 @@ ifeq ($(STATIC_LIBSTDCPP),1)
 endif
 
 ifeq ($(UNAME),Darwin)
-	CFLAGS += -stdlib=libc++
 	CXXFLAGS += -stdlib=libc++
 	LDFLAGS += -stdlib=libc++
 endif


### PR DESCRIPTION
Closes #129 (should probably also close #120)