### PR TITLE
Tweak workaround

### DIFF
--- a/src/libsass/src/memory/shared_ptr.hpp
+++ b/src/libsass/src/memory/shared_ptr.hpp
@@ -14,7 +14,7 @@
 // Workaround for what appears to be a false positive (Wuse-after-free) warning in gcc-12 on Windows.
 // See here for evidence of other false positives: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=Wuse-after-free
 // And here for a discussion of the issue: https://github.com/rstudio/sass/issues/127
-#if __GNUC__ > 11 && _WIN32
+#if __GNUC__ == 12 && _WIN32
 /*IGNORE*/ #pragma GCC diagnostic push
 /*IGNORE*/ #pragma GCC diagnostic ignored "-Wuse-after-free"
 #endif


### PR DESCRIPTION
The bug in gcc that was causing this warning has been fixed in gcc-13. Cf: https://github.com/ropensci/qpdf/commit/2621b3fd958d28704309a0dd14a950cb7763fef7