### PR TITLE
More explicit message when caching a google font

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # sass (development version)
 
-- More informative output when sass downloads a google font to the local cache.
+- More informative output when `font_google()` downloads google font files (for `font_google(local=TRUE)`).
 
 # sass 0.4.9
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # sass (development version)
 
+- More informative output when sass downloads a google font to the local cache.
+
 # sass 0.4.9
 
 - Closed #138: font_google(local = TRUE) now uses woff2 (instead of woff) for a font file type. (#139) 

--- a/R/fonts.R
+++ b/R/fonts.R
@@ -414,6 +414,7 @@ font_dep_google_local <- function(x) {
   dir.create(tmpdir, recursive = TRUE)
   css_file <- file.path(tmpdir, "font.css")
 
+  needs_message <- is_cache_object(x$cache)
   x$cache <- resolve_cache(x$cache)
 
   css_key <- hash_with_user_agent(x$href)
@@ -426,8 +427,6 @@ font_dep_google_local <- function(x) {
   # basename() of these url()s contain a hash key of the font data
   urls <- extract_group(css, "url\\(([^)]+)")
   basenames <- basename(urls)
-
-  informed <- FALSE
 
   # If need be, download the font file(s) that the CSS imports,
   # and modify the CSS to point to the local files
@@ -443,9 +442,9 @@ font_dep_google_local <- function(x) {
       x$cache$remove(css_key)
       return(font_dep_google_local(x))
     }
-    if (!informed) {
+    if (needs_message) {
       rlang::inform(paste0("Downloading google font ", x$family, " to local cache"))
-      informed <<- TRUE
+      needs_message <<- FALSE
     }
     
     download_file(url, f, quiet = TRUE)

--- a/R/fonts.R
+++ b/R/fonts.R
@@ -443,7 +443,9 @@ font_dep_google_local <- function(x) {
       return(font_dep_google_local(x))
     }
     if (needs_message) {
-      rlang::inform(paste0("Downloading google font ", x$family, " to local cache"))
+      rlang::inform(paste0(
+        "Downloading google font ", x$family, " to local cache (", x$cache$dir(), ")"
+      ))
       needs_message <<- FALSE
     }
     

--- a/tests/testthat/_snaps/font-objects.md
+++ b/tests/testthat/_snaps/font-objects.md
@@ -188,6 +188,18 @@
 # font_google(local = TRUE) basically works
 
     Code
+      tagz <- renderTags(tags$style(sass(scss)))
+    Message
+      Downloading google font Pacifico to local cache
+
+---
+
+    Code
+      tagz <- renderTags(tags$style(sass(scss)))
+
+---
+
+    Code
       tagz$html
     Output
       <style>body {

--- a/tests/testthat/_snaps/font-objects.md
+++ b/tests/testthat/_snaps/font-objects.md
@@ -190,7 +190,7 @@
     Code
       tagz <- renderTags(tags$style(sass(scss)))
     Message
-      Downloading google font Pacifico to local cache
+      Downloading google font Pacifico to local cache (<temp-cache>)
 
 ---
 

--- a/tests/testthat/test-font-objects.R
+++ b/tests/testthat/test-font-objects.R
@@ -62,7 +62,10 @@ test_that("font_google(local = TRUE) basically works", {
   )
 
   # 1st time rendering font should add files to cache
-  expect_snapshot(tagz <- renderTags(tags$style(sass(scss))))
+  expect_snapshot(
+    tagz <- renderTags(tags$style(sass(scss))),
+    transform = function(x) gsub(normalizePath(tmpdir), "<temp-cache>", x)
+  )
   size <- cache$size()
   expect_true(size > 0)
 

--- a/tests/testthat/test-font-objects.R
+++ b/tests/testthat/test-font-objects.R
@@ -62,12 +62,12 @@ test_that("font_google(local = TRUE) basically works", {
   )
 
   # 1st time rendering font should add files to cache
-  tagz <- renderTags(tags$style(sass(scss)))
+  expect_snapshot(tagz <- renderTags(tags$style(sass(scss))))
   size <- cache$size()
   expect_true(size > 0)
 
   # 2md time should result in cache hit
-  tagz <- renderTags(tags$style(sass(scss)))
+  expect_snapshot(tagz <- renderTags(tags$style(sass(scss))))
   expect_true(size == cache$size())
 
   # Make sure the markup structure and files are as expected

--- a/tests/testthat/test-font-objects.R
+++ b/tests/testthat/test-font-objects.R
@@ -64,7 +64,7 @@ test_that("font_google(local = TRUE) basically works", {
   # 1st time rendering font should add files to cache
   expect_snapshot(
     tagz <- renderTags(tags$style(sass(scss))),
-    transform = function(x) gsub(normalizePath(tmpdir), "<temp-cache>", x)
+    transform = function(x) gsub("\\(.*\\)", "(<temp-cache>)", x)
   )
   size <- cache$size()
   expect_true(size > 0)


### PR DESCRIPTION
Opened mostly to start discussion about what the preferred interface is — I assumed that you'll usually be downloading multiple files for a single font but you'll only want to be informed once. Let me know if there's something different that you'd prefer.