### PR TITLE
Fix rchk unprotected variable

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -25,11 +25,11 @@ const char* get_char_element(SEXP list, const char* name) {
   int index = get_index(list, name);
   SEXP value = PROTECT(VECTOR_ELT(list, index));
   if (TYPEOF(value) != STRSXP) {
-    UNPROTECT(1);
     error("Invalid type for %s option. Expected string.", name);
   }
+  value = asChar(value);
   UNPROTECT(1);
-  return CHAR(asChar(value));
+  return CHAR(value);
 }
 
 int get_bool_element(SEXP list, const char* name) {


### PR DESCRIPTION
## Pull Request

Fixes #145.

This is in fact a false positive as the prior `STRSXP` check means we only ever go down the non-allocating `STRSXP` branch of `asChar`. But this commit will silence `rchk` (tested locally).