### PR TITLE
Follow up for PR#148 Fix CRAN check warnings

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -11,7 +11,7 @@ $(STATLIB):
 	MAKEFLAGS= CC="$(CC)" CFLAGS="$(CFLAGS)" CXX="$(CXX)" AR="$(AR)" LDFLAGS="$(LDFLAGS)" $(MAKE) -C libsass
 
 cleanup: $(SHLIB)
-	rm -f $(STATLIB)
+	@rm -f $(STATLIB)
 
 clean:
 	MAKEFLAGS= $(MAKE) -C libsass clean


### PR DESCRIPTION
A tiny follow-up to #148. Apparently this is now 'best practice'.
