### PR TITLE
Fix throwing exceptions under Emscripten

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # sass (development version)
 
+- Fixed throwing exceptions when running under Emscripten.
+
 # sass 0.4.10
 
 - Closed #149: `FileCache` R6 class `finalize()` method should be private. (#150)

--- a/src/libsass/Makefile
+++ b/src/libsass/Makefile
@@ -73,6 +73,10 @@ else
 	STATIC_LIBSTDCPP ?= 0
 endif
 
+ifeq (Emscripten,$(UNAME))
+	CXXFLAGS += -fwasm-exceptions
+endif
+
 ifndef SASS_LIBSASS_PATH
 	SASS_LIBSASS_PATH = .
 endif


### PR DESCRIPTION
By default, [C++ exceptions are disabled in Emscripten](https://emscripten.org/docs/porting/exceptions.html). They are opt-in by setting a particular flag at compile and link time.

The webR R package cross-compiler, {rwasm}, adds the required flag at link time, but we also need to provide it at compile time when building `libsass`.  This PR makes that change.

Fixes https://github.com/r-wasm/webr/issues/525.