### PR TITLE
Fix copy and clean-up problems on immutable OS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # sass (development version)
 
 - Fixed throwing exceptions when running under Emscripten.
+- Copy files without inheriting read/write/execute permissions fixing issues when using sass on immutable operating systems.
 
 # sass 0.4.10
 

--- a/R/file_cache.R
+++ b/R/file_cache.R
@@ -194,7 +194,7 @@ FileCache <- R6::R6Class("FileCache",
 
       cache_file <- private$filename_full_path(key)
 
-      if (file.copy(cache_file, outfile, overwrite = overwrite)) {
+      if (file.copy(cache_file, outfile, overwrite = overwrite, copy.mode = FALSE)) {
         private$log(paste0('get: key "', key, '" found and copied to ', outfile))
         if (private$evict == "lru"){
           Sys.setFileTime(cache_file, Sys.time())
@@ -264,7 +264,7 @@ FileCache <- R6::R6Class("FileCache",
 
       cache_file <- private$filename_full_path(key)
 
-      success <- file.copy(infile, cache_file, overwrite = TRUE)
+      success <- file.copy(infile, cache_file, overwrite = TRUE, copy.mode = FALSE)
       if (success) {
         private$log(paste0('set: key "', key, ' from file ', infile))
       } else {

--- a/R/layers.R
+++ b/R/layers.R
@@ -479,7 +479,8 @@ write_file_attachments <- function(file_attachments, output_path) {
         dir(src, all.files = TRUE, full.names = TRUE, no.. = TRUE),
         dest,
         overwrite = TRUE,
-        recursive = TRUE
+        recursive = TRUE,
+        copy.mode = FALSE
       )
       return(NULL)
     }


### PR DESCRIPTION
The `sass` library create problems when used on an [immutable system](https://itsfoss.com/immutable-linux-distros/) like NixOS, see [GitHub issue](https://github.com/rstudio/bslib/issues/1281) for more context. The same problem has been solved in [`officer` package](https://github.com/davidgohel/officer/commit/23275a95169ef41ab52567c62273e705922002ac) in an identical manner. 

I do not think it is possible to add unit tests in the tests/testthat directory.  Note that the [style guideline](http://r-pkgs.had.co.nz/style.html) returns a 404 error.

- [x] Run `devtools::check()` (or, equivalently, click on Build->Check Package in the RStudio IDE) to make sure your change did not add any messages, warnings, or errors.
    * Note there is a decent chance that some tests were already failing before your changes. Just make sure you haven't introduced any new ones.

- [x] Add an entry to NEWS.md concisely describing what was changed.
